### PR TITLE
Don't propose public domain licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,13 @@
-You can use this plugin under terms of CC0/Public Domain (or similar) license,
-if your local laws allow it. If they doesn't, you can use it under terms of
-MIT/X11 license. In any way, please, respect the right of authorship of plugin
-authors and don't try to assign authorship to you. Also, if you made any
-changes, we'll be happy to see Pull Request from you (via GitHub or by E-Mail).
+The MIT License (MIT)
 
-Here is the text of MIT/X11 license, if any:
+Copyright (c) 2011-2017 redmine_xmpp_notifications plugin contributors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
@@ -23,3 +19,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+


### PR DESCRIPTION
В апстриме [предложил](https://github.com/alphallc/redmine_xmpp_notifications/pull/14) это изменение лицензии, неизвестно когда они его примут, но по условиям мы можем менять лицензию, так что думаю стоит его принять. Двойное лицензирование PD/MIT не рекомендуется и не очень много смысла в этом. Здесь лицензия заменена на только MIT.

> It's not recommended, let's stricly use MIT instead
>
> https://softwareengineering.stackexchange.com/questions/76148/what-is-the-difference-between-releasing-code-under-the-bsd-license-and-releasin
